### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Google auth plugin for Kallithea source code management system.
 .. image:: https://api.travis-ci.org/paylogic/kallithea-auth-google.png
    :target: https://travis-ci.org/paylogic/kallithea-auth-google
 
-.. image:: https://pypip.in/v/kallithea-auth-google/badge.png
+.. image:: https://img.shields.io/pypi/v/kallithea-auth-google.svg
    :target: https://crate.io/packages/kallithea-auth-google/
 
 .. image:: https://coveralls.io/repos/paylogic/kallithea-auth-google/badge.png?branch=master


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20kallithea-auth-google))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `kallithea-auth-google`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.